### PR TITLE
Use linear strategy for bootstrap pre tasks

### DIFF
--- a/playbooks/bootstrap.yaml
+++ b/playbooks/bootstrap.yaml
@@ -6,6 +6,7 @@
 - name: Install packages
   hosts: all
   gather_facts: false
+  strategy: linear
   vars:
     interpreter_pkgs:
       - python3


### PR DESCRIPTION
Rationale: we often use mitogen, but python is not installed yet.
