### PR TITLE
apache: Add finer controls for SSL configuration

### DIFF
--- a/playbooks/group_vars/acme_clients.yaml
+++ b/playbooks/group_vars/acme_clients.yaml
@@ -4,7 +4,10 @@
 # Reusable defaults for ACME (letsencrypt) clients.
 # =============================================================================
 
+# Until a role/playbook is written, this is only informative.
+dehydrated__enable: true
+
 apt__packages_to_install__acme:
   - dehydrated
 apt__packages_to_install__acme_apache: |-
-  {{ ['dehydrated-apache2'] if 'apache_servers' in group_names else [] }}
+  {{ ['dehydrated-apache2'] if apache2__enable else [] }}

--- a/playbooks/group_vars/all/00-defaults.yaml
+++ b/playbooks/group_vars/all/00-defaults.yaml
@@ -68,7 +68,7 @@ ferm__enable: false
 fail2ban__enable: true
 fail2ban__install_ferm_svc: '{{ ferm__enable | bool }}'
 
-# Role: simple-bind
+# Role: simple_bind
 # -----------------------------------------------------------------------------
 
 simple_bind__enable: false
@@ -84,7 +84,7 @@ resolv_nameservers: |-
   }}
 resolv_domain: '{{ domain_name | d(omit) }}'
 
-# Role: prometheus-node-exporter
+# Role: node_exporter
 # -----------------------------------------------------------------------------
 
 node_exporter__enable: true
@@ -103,7 +103,7 @@ node_exporter__extra_args: |
   --collector.cpu.info
   {% endif %}
 
-# Role: prometheus_blackbox_exporter
+# Role: blackbox_exporter
 # -----------------------------------------------------------------------------
 
 blackbox_exporter__enable: false
@@ -126,3 +126,8 @@ glauth__enable: false
 
 tinc__netname: tinc
 tinc__install_ferm_svc: '{{ ferm__enable | bool }}'
+
+# Not yet a role: dehydrated
+# -----------------------------------------------------------------------------
+dehydrated__enable: false
+dehydrated__cert_path: /var/lib/dehydrated/certs

--- a/playbooks/group_vars/all/14-apache.yaml
+++ b/playbooks/group_vars/all/14-apache.yaml
@@ -14,19 +14,28 @@ apache2__logdirs__base:
 # Configurable settings for these templates.
 # -----------------------------------------------------------------------------
 
+# Enable the `SSL` module.
+apache2__use_ssl: '{{ apache2__use_md or dehydrated__enable }}'
 # Enable the `MD` module for automatic SSL certificate creation.
 apache2__use_md: false
 
+# Enable and configure the default SSL site.
+apache2__default_ssl_enable: '{{ apache2__use_ssl }}'
+# Use `MD` for the default SSL site.
+apache2__default_ssl_uses_md: '{{ apache2__use_md }}'
 # Certificate directory for the default SSL site (when not using `MD`).
 apache2__default_ssl_cert_path: |-
   {{ '%s/%s' % (dehydrated__cert_path, host_fqdn) }}
+# Force HTTPS redirects in the default site.
+apache2__default_site_force_ssl: '{{ apache2__default_ssl_enable }}'
 
 # Generated templates
 # -----------------------------------------------------------------------------
 
 apache2__mods__base:
   rewrite:
-    state: enabled
+    state: |-
+      {{ 'enabled' if apache2__default_site_force_ssl else 'absent' }}
 
 apache2__sites__base:
   000-default:
@@ -39,25 +48,30 @@ apache2__sites__base:
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 
+      {% if apache2__default_site_force_ssl %}
         RewriteEngine On
+      {% if dehydrated__enable %}
         RewriteRule ^/.well-known/acme-challenge/.* - [L]
+      {% endif %}
         RewriteCond %{HTTPS} off
         RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+      {% endif %}
       </VirtualHost>
 
-apache2__listen_https__ssl: [443]
+apache2__listen_https__ssl: '{{ [443] if apache2__use_ssl else [] }}'
 
 apache2__mods__ssl:
   md:
-    state:  |-
-      {{ 'enabled' if apache2__use_md else 'absent' }}
+    state: |-
+      {{ 'enabled' if apache2__use_ssl and apache2__use_md else 'absent' }}
   ssl:
-    state: enabled
+    state: |-
+      {{ 'enabled' if apache2__use_ssl else 'absent' }}
 
 apache2__conf__ssl:
   md:
-    state:  |-
-      {{ 'enabled' if apache2__use_md else 'absent' }}
+    state: |-
+      {{ 'enabled' if apache2__use_ssl and apache2__use_md else 'absent' }}
     src: |
       MDCertificateAgreement accepted
 
@@ -65,10 +79,11 @@ apache2__sites__ssl:
   001-default-ssl:
     state: |-
       {{
-        'enabled' if apache2__use_md or dehydrated__enable else 'absent'
+        'enabled' if apache2__use_ssl and apache2__default_ssl_enable else
+        'absent'
       }}
     src: |
-      {% if apache2__use_md %}
+      {% if apache2__default_ssl_uses_md %}
       MDomain {{ host_fqdn }}
       {% endif %}
 
@@ -81,7 +96,7 @@ apache2__sites__ssl:
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 
         SSLEngine On
-      {% if not apache2__use_md %}
+      {% if not apache2__default_ssl_uses_md %}
         SSLCertificateFile      {{ apache2__default_ssl_cert_path }}/cert.pem
         SSLCertificateKeyFile   {{ apache2__default_ssl_cert_path }}/privkey.pem
         SSLCertificateChainFile {{ apache2__default_ssl_cert_path }}/chain.pem

--- a/playbooks/group_vars/all/14-apache.yaml
+++ b/playbooks/group_vars/all/14-apache.yaml
@@ -12,8 +12,6 @@ apache2__listen_http__base:
 apache2__listen_https__base:
   - 443
 
-# TODO: move dehydrated__cert_path to a proper location
-dehydrated__cert_path: /var/lib/dehydrated/certs
 
 _a2_md_state: '{{ "enabled" if apache2__use_md else "absent" }}'
 _a2_cert_path: '{{ "%s/%s" % (dehydrated__cert_path, host_fqdn) }}'

--- a/playbooks/group_vars/all/14-apache.yaml
+++ b/playbooks/group_vars/all/14-apache.yaml
@@ -5,34 +5,28 @@
 # =============================================================================
 
 apache2__enable: false
-apache2__use_md: false
 apache2__install_ferm_svc: '{{ ferm__enable | bool }}'
-apache2__listen_http__base:
-  - 80
-apache2__listen_https__base:
-  - 443
+apache2__listen_http__base: [80]
+apache2__listen_https__base: []
+apache2__logdirs__base:
+  - /var/log/apache2
 
+# Configurable settings for these templates.
+# -----------------------------------------------------------------------------
 
-_a2_md_state: '{{ "enabled" if apache2__use_md else "absent" }}'
-_a2_cert_path: '{{ "%s/%s" % (dehydrated__cert_path, host_fqdn) }}'
-_a2_sslsite_state: |-
-  {{
-    'enabled' if apache2__use_md or 'acme_clients' in group_names else 'absent'
-  }}
+# Enable the `MD` module for automatic SSL certificate creation.
+apache2__use_md: false
+
+# Certificate directory for the default SSL site (when not using `MD`).
+apache2__default_ssl_cert_path: |-
+  {{ '%s/%s' % (dehydrated__cert_path, host_fqdn) }}
+
+# Generated templates
+# -----------------------------------------------------------------------------
 
 apache2__mods__base:
-  md:
-    state: '{{ _a2_md_state }}'
   rewrite:
     state: enabled
-  ssl:
-    state: enabled
-
-apache2__conf__base:
-  md:
-    state: '{{ _a2_md_state }}'
-    src: |
-      MDCertificateAgreement accepted
 
 apache2__sites__base:
   000-default:
@@ -50,8 +44,29 @@ apache2__sites__base:
         RewriteCond %{HTTPS} off
         RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
       </VirtualHost>
+
+apache2__listen_https__ssl: [443]
+
+apache2__mods__ssl:
+  md:
+    state:  |-
+      {{ 'enabled' if apache2__use_md else 'absent' }}
+  ssl:
+    state: enabled
+
+apache2__conf__ssl:
+  md:
+    state:  |-
+      {{ 'enabled' if apache2__use_md else 'absent' }}
+    src: |
+      MDCertificateAgreement accepted
+
+apache2__sites__ssl:
   001-default-ssl:
-    state: '{{ _a2_sslsite_state }}'
+    state: |-
+      {{
+        'enabled' if apache2__use_md or dehydrated__enable else 'absent'
+      }}
     src: |
       {% if apache2__use_md %}
       MDomain {{ host_fqdn }}
@@ -67,11 +82,8 @@ apache2__sites__base:
 
         SSLEngine On
       {% if not apache2__use_md %}
-        SSLCertificateFile      {{ _a2_cert_path }}/cert.pem
-        SSLCertificateKeyFile   {{ _a2_cert_path }}/privkey.pem
-        SSLCertificateChainFile {{ _a2_cert_path }}/chain.pem
+        SSLCertificateFile      {{ apache2__default_ssl_cert_path }}/cert.pem
+        SSLCertificateKeyFile   {{ apache2__default_ssl_cert_path }}/privkey.pem
+        SSLCertificateChainFile {{ apache2__default_ssl_cert_path }}/chain.pem
       {% endif %}
       </VirtualHost>
-
-apache2__logdirs__base:
-  - /var/log/apache2


### PR DESCRIPTION
* 2bfbced - Set defaults for dehydrated
* fb9ac8e - Separate SSL configuration for clarity
* 5003997 - Add finer controls for SSL configuration
  * apache2__use_ssl: Enable the `SSL` module.
  * apache2__default_ssl_enable: Enable and configure the default SSL site.
  * apache2__default_ssl_uses_md: Use `MD` for the default SSL site.
  * apache2__default_ssl_cert_path: Certificate directory for the default SSL
   site (when not using `MD`).
  * apache2__default_site_force_ssl: Force HTTPS redirects in the default site.