### PR TITLE
NTP and bind fixes

### DIFF
--- a/playbooks/group_vars/all/00-defaults.yaml
+++ b/playbooks/group_vars/all/00-defaults.yaml
@@ -58,9 +58,7 @@ net__enable: false
 
 ntp_enabled: true
 ntp_timezone: Etc/UTC
-
 ntp_manage_config: true
-ntp_driftfile: /var/lib/ntp/ntp.drift
 
 # Role: ferm
 # -----------------------------------------------------------------------------

--- a/roles/bind_config/tasks/main.yaml
+++ b/roles/bind_config/tasks/main.yaml
@@ -16,10 +16,7 @@
     group: bind
     mode: '0644'
     force: true
-  with_fileglob:
-    - '{{ bind_config__conf_files }}'
-  loop_control:
-    label: '{{ item | basename }}'
+  with_items: '{{ bind_config__conf_files }}'
   notify:
     - _tina_validate_bind9_conf
     - _tina_reload_bind9


### PR DESCRIPTION
* 5ab6a6e - ntp: stop forcing the driftfile path
* 02603d0 - bind_config: accept a list of paths to copy recursively
  Using `file_glob` makes it very hard to copy nested subdirectories while 
  preserving the structure; with this change, each path is passed directly to
  `copy` which copies recursively maintaining the original directory hierarchy.