### PR TITLE
Fix a bug in aggregation templates

### DIFF
--- a/playbooks/group_vars/libvirt_guests.yaml
+++ b/playbooks/group_vars/libvirt_guests.yaml
@@ -43,9 +43,9 @@ vm_params: {}
 # Discover custom configurations using var prefixes
 # (e.g. vm_volume__root).
 vm_volumes: |-
-  {{ query('vars', *(query('varnames', '^vm_volume__.*') | select | sort)) }}
+  {{ query('vars', *(query('varnames', '^vm_volume__.*') | sort)) | select }}
 vm_interfaces: |-
-  {{ query('vars', *(query('varnames', '^vm_interface__.*') | select | sort)) }}
+  {{ query('vars', *(query('varnames', '^vm_interface__.*') | sort)) | select }}
 
 vm_image_variant: genericcloud
 # Uses variables computed by 25-apt-calculated.yaml.

--- a/playbooks/group_vars/promtail_servers/00-defaults.yaml
+++ b/playbooks/group_vars/promtail_servers/00-defaults.yaml
@@ -23,8 +23,10 @@ promtail__clients: |
   {{- res -}}
 
 promtail__scrape_configs: |-
-  {{ query('vars', *(query('varnames', '^promtail__scrape_config__.*')
-     | select | sort)) }}
+  {{
+    query('vars', *(query('varnames', '^promtail__scrape_config__.*') | sort)) |
+    select
+  }}
 promtail__scrape_config__varlogs:
   job_name: varlogs
   static_configs:


### PR DESCRIPTION
This commit corrects a bug where aggregation of variables containing single items into a list was not filtering `null` items correctly.