### PR TITLE
Misc improvements

### DIFF
--- a/playbooks/apt.yaml
+++ b/playbooks/apt.yaml
@@ -6,6 +6,7 @@
 - name: Configure APT and install required packages
   hosts: all
   become: true
+  gather_facts: true
   roles:
     - role: tina_pm.common.apt
       tags: apt

--- a/playbooks/base_setup.yaml
+++ b/playbooks/base_setup.yaml
@@ -5,6 +5,7 @@
 - name: Set up host base configuration
   hosts: '{{ target_hosts | d("all") }}'
   become: true
+  gather_facts: true
   roles:
     - role: tina_pm.common.base_setup
       tags: base_setup

--- a/playbooks/dropbear_initramfs.yaml
+++ b/playbooks/dropbear_initramfs.yaml
@@ -1,8 +1,8 @@
 # vim:ts=2:sw=2:et:ai:sts=2
 
-# Playbook: Manage dropbear-initramfs authorized keys.
+# Playbook: Manage remote disk unlocking with dropbear-initramfs.
 ---
-- name: Manage dropbear-initramfs authorized keys
+- name: Manage remote disk unlocking with dropbear-initramfs
   hosts: all
   become: true
   gather_facts: false

--- a/playbooks/group_vars/all/90-ansible.yaml
+++ b/playbooks/group_vars/all/90-ansible.yaml
@@ -4,6 +4,9 @@
 # Ansible configuration.
 # =============================================================================
 
+# Use FQDNs for connecting, delegate connection details to SSH configuration.
+ansible_host: '{{ host_fqdn }}'
+
 # Override interpreter location according to Debian default configurations.
 ansible_python_interpreter: |-
   {{

--- a/playbooks/group_vars/libvirt_guests.yaml
+++ b/playbooks/group_vars/libvirt_guests.yaml
@@ -33,7 +33,7 @@ bootstrap__install_packages__libvirt:
   - qemu-guest-agent  # Needed for ansible/libvirt connection.
 
 # VM definition parameters.
-vm_name: '{{ inventory_hostname }}'
+vm_name: '{{ inventory_hostname_short }}'
 vm_default_params:
   memory_mb: 1024
   vcpus: 1
@@ -54,27 +54,30 @@ vm_image_url:
     apt__distro_ver }}-{{ vm_image_variant }}-amd64.qcow2
 
 vm_volume__00_root:
-  dev: /dev/vg0/vm-{{ inventory_hostname }}-root
+  dev: /dev/vg0/vm-{{ inventory_hostname_short }}-root
   target: vda
   type: block
   size: 10G
   format: raw
   mount: ~  # Partitioned device.
 
+_host_iface_prefix: |-
+  {% set _len = ('vm-%s-en0' % vm_name) | length %}
+  {{ 'vm-%s' % (vm_name if _len <= 15 else vm_name[:15 - _len]) }}
 vm_interface__00_pubbr:
   type: bridge
   mac: '{{ pubnet_hwaddr }}'
   source:
     dev: vmbr0
   target:
-    dev: vm-{{ vm_name }}-en0
+    dev: '{{ _host_iface_prefix }}-en0'
 vm_interface__01_privbr:
   type: bridge
   mac: '{{ privnet_hwaddr }}'
   source:
     dev: vmbr1
   target:
-    dev: vm-{{ vm_name }}-en1
+    dev: '{{ _host_iface_prefix }}-en1'
 
 # Construct complete VM definition.
 libvirt__vm_def: |-

--- a/playbooks/group_vars/libvirt_hosts.yaml
+++ b/playbooks/group_vars/libvirt_hosts.yaml
@@ -11,9 +11,10 @@ libvirt_hosts__masquerade: false
 libvirt_hosts__forwarding_ext_ifaces: []
 libvirt_hosts__forwarding_int_ifaces: []
 
-# Needed for network set-up.
-base_setup__pkg_install__libvirt:
+# Needed for network set-up during host's bootstrap.
+bootstrap__install_packages__libvirt:
   - bridge-utils
+base_setup__pkg_install__libvirt: '{{ bootstrap__install_packages__libvirt }}'
 
 users__admin_groups__libvirt:
   - libvirt

--- a/playbooks/net.yaml
+++ b/playbooks/net.yaml
@@ -4,6 +4,7 @@
 ---
 - name: Configure network interfaces
   hosts: '{{ target_hosts | d("all") }}'
+  become: true
   roles:
     - role: tina_pm.common.net
       when: net__enable

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -6,7 +6,7 @@
 - name: Set up host base configuration
   import_playbook: ./base_setup.yaml
 
-- name: Manage dropbear-initramfs authorized keys
+- name: Manage remote disk unlocking with dropbear-initramfs
   import_playbook: ./dropbear_initramfs.yaml
 
 - name: Install and configure VPN

--- a/roles/dropbear_initramfs/defaults/main.yaml
+++ b/roles/dropbear_initramfs/defaults/main.yaml
@@ -3,6 +3,20 @@
 # SSH public keys allowed to log in to the initramfs.
 dropbear_initramfs__authorized_keys: ~
 
+# Boot-time network configuration, as accepted by the kernel command line `ip=`
+# parameter. For details, see
+# https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+#
+# Format:
+#   <client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:
+#   <dns0-ip>:<dns1-ip>:<ntp0-ip>
+#
+dropbear_initramfs__ipconfig: dhcp
+
 # Path to the authorized_keys file.
 dropbear_initramfs__authorized_keys_file:
   /etc/dropbear/initramfs/authorized_keys
+
+# Path to the initramfs-tools configuration file.
+dropbear_initramfs__conf_file:
+  /etc/initramfs-tools/initramfs.conf

--- a/roles/dropbear_initramfs/tasks/main.yaml
+++ b/roles/dropbear_initramfs/tasks/main.yaml
@@ -19,3 +19,12 @@
     manage_dir: false
     exclusive: true
   notify: _tina_update_initramfs
+
+- name: Set boot-time network parameters
+  ansible.builtin.lineinfile:
+    dest: '{{ dropbear_initramfs__conf_file }}'
+    line: IP={{ dropbear_initramfs__ipconfig }}
+    regexp: '^IP[ =]'
+    state: present
+  notify: _tina_update_initramfs
+  when: dropbear_initramfs__ipconfig


### PR DESCRIPTION
* 9baf83c - dropbear_initramfs: add management of boot-time networking
* fda581f - playbooks: add needed become/gather_flags settings
* 0ddf731 - Use FQDNs for connecting, details in SSH config
* 9982d66 - libvirt_guests: avoid device/vm name overruns
* 1f4e0b2 - libvirt_hosts: install `bridge-utils` before net config