### PR TITLE
Add `trusted_networks` setting

### DIFF
--- a/playbooks/group_vars/alertmanager_servers.yaml
+++ b/playbooks/group_vars/alertmanager_servers.yaml
@@ -15,9 +15,9 @@ ferm__services__alertmanager:
   alertmanager:
     dport: 9093
     proto: tcp
-    saddr: '{{ internal_networks }}'
+    saddr: '{{ trusted_networks }}'
 
   alertmanager-gossip:
     dport: 9094
     proto: tcp
-    saddr: '{{ internal_networks }}'
+    saddr: '{{ trusted_networks }}'

--- a/playbooks/group_vars/all/00-defaults.yaml
+++ b/playbooks/group_vars/all/00-defaults.yaml
@@ -14,16 +14,25 @@ host_name: '{{ inventory_hostname_short }}'
 host_fqdn: '{{ inventory_hostname_short }}.{{ inventory_domain_name }}'
 
 # General network parameters.
+# -----------------------------------------------------------------------------
 nameservers:
   - 8.8.8.8
 
+# Networks directly connected to this host.
 local_networks: []
+# Private/internal, not globally routable networks.
 internal_networks: []
+# Link-local addressed networks.
 link_local_networks:
   - 169.254/16
   - 'fe80::/10'
 
+# Trusted private networks.
+# -----------------------------------------------------------------------------
+trusted_networks: '{{ internal_networks }}'
+
 # Host environments.
+# -----------------------------------------------------------------------------
 envs:
   - prod
   - test
@@ -99,7 +108,7 @@ resolv_domain: '{{ domain_name | d(omit) }}'
 
 node_exporter__enable: true
 node_exporter__install_ferm_svc: '{{ ferm__enable | bool }}'
-node_exporter__allow_from: '{{ internal_networks }}'
+node_exporter__allow_from: '{{ trusted_networks }}'
 node_exporter__listen_addr: ''
 node_exporter__listen_port: 9100
 node_exporter__disk_ignored_devs:
@@ -117,7 +126,7 @@ node_exporter__extra_args: |
 # -----------------------------------------------------------------------------
 
 blackbox_exporter__enable: false
-blackbox_exporter__allow_from: '{{ internal_networks }}'
+blackbox_exporter__allow_from: '{{ trusted_networks }}'
 blackbox_exporter__install_ferm_svc: '{{ ferm__enable | bool }}'
 
 # Role: mtail

--- a/playbooks/group_vars/all/20-prometheus.yaml
+++ b/playbooks/group_vars/all/20-prometheus.yaml
@@ -5,7 +5,7 @@
 # =============================================================================
 
 prometheus__install_ferm_svc: '{{ ferm__enable | bool }}'
-prometheus__allow_from: '{{ internal_networks }}'
+prometheus__allow_from: '{{ trusted_networks }}'
 
 prometheus__rules__base:
   - files/prometheus/rules/node-basic.rules.yml

--- a/playbooks/group_vars/all/21-grafana.yaml
+++ b/playbooks/group_vars/all/21-grafana.yaml
@@ -6,7 +6,7 @@
 grafana__enable: false
 
 grafana__install_ferm_svc: '{{ ferm__enable | bool }}'
-grafana__ferm_allow_from: '{{ internal_networks }}'
+grafana__ferm_allow_from: '{{ trusted_networks }}'
 
 grafana__server__domain: monitoring.{{ domain_name }}
 grafana__smtp__from_address: grafana@{{ host_fqdn }}

--- a/playbooks/group_vars/promtail_servers/00-defaults.yaml
+++ b/playbooks/group_vars/promtail_servers/00-defaults.yaml
@@ -7,7 +7,7 @@ promtail__storage_dir: /var/lib/promtail
 # If true, install ferm configuration file.
 promtail__install_ferm_svc: '{{ ferm__enable | bool }}'
 # Optionally limit access to a list of IP addresses.
-promtail__ferm_allow_from: '{{ internal_networks }}'
+promtail__ferm_allow_from: '{{ trusted_networks }}'
 
 # List of Loki instances to push logs to.
 promtail__client_urls: []

--- a/roles/loki/defaults/main.yaml
+++ b/roles/loki/defaults/main.yaml
@@ -8,5 +8,5 @@ loki__storage_dir: /var/lib/loki
 # If true, install ferm configuration file.
 loki__install_ferm_svc: '{{ ferm__enable | bool }}'
 # Optionally limit access to a list of IP addresses.
-loki__http_ferm_allow_from: '{{ internal_networks }}'
-loki__grpc_ferm_allow_from: '{{ internal_networks }}'
+loki__http_ferm_allow_from: '{{ trusted_networks }}'
+loki__grpc_ferm_allow_from: '{{ trusted_networks }}'


### PR DESCRIPTION
Up to now, the `internal_networks` was used for routing configurations as well as for access control. This new variable helps separate concerns.