### PR TITLE
dropbear_initramfs: fix conditionals [compat-2.19]

### DIFF
--- a/roles/dropbear_initramfs/tasks/main.yaml
+++ b/roles/dropbear_initramfs/tasks/main.yaml
@@ -27,4 +27,4 @@
     regexp: '^IP[ =]'
     state: present
   notify: _tina_update_initramfs
-  when: dropbear_initramfs__ipconfig
+  when: dropbear_initramfs__ipconfig is ansible.builtin.truthy


### PR DESCRIPTION
A small 2.19 fix that I missed.