### PR TITLE
Various small fixes and improvements

### DIFF
--- a/playbooks/create_vm.yaml
+++ b/playbooks/create_vm.yaml
@@ -173,6 +173,21 @@
       loop: '{{ _target_hosts }}'
       changed_when: true
 
+    - name: Disable cloud-init before first boot
+      ansible.builtin.command:
+        cmd: |
+          virt-customize -d {{ item }} --touch /etc/cloud/cloud-init.disabled
+      loop: '{{ _target_hosts }}'
+      changed_when: true
+
+    - name: Disable systemd-networkd before first boot
+      ansible.builtin.command:
+        cmd: >
+          virt-customize -d {{ item }} --run-command
+            systemctl mask systemd-networkd.service
+      loop: '{{ _target_hosts }}'
+      changed_when: true
+
     - name: Start VM domains
       community.libvirt.virt:
         state: running

--- a/playbooks/create_vm.yaml
+++ b/playbooks/create_vm.yaml
@@ -184,7 +184,7 @@
       ansible.builtin.command:
         cmd: >
           virt-customize -d {{ item }} --run-command
-            systemctl mask systemd-networkd.service
+            'systemctl mask systemd-networkd.service'
       loop: '{{ _target_hosts }}'
       changed_when: true
 

--- a/playbooks/files/mtail/apache_metrics.mtail
+++ b/playbooks/files/mtail/apache_metrics.mtail
@@ -1,0 +1,47 @@
+# Copyright 2015 Ben Kochie <superq@gmail.com>. All Rights Reserved.
+# This file is available under the Apache license.
+
+# Parser for a metrics-friendly apache log format
+# LogFormat "%v:%p %R %m %>s %H conn=%X %D %O %I %k" metrics
+counter http_connections_aborted_total by server_port, handler, method, code, protocol, connection_status
+counter http_connections_closed_total by server_port, handler, method, code, protocol, connection_status
+
+counter http_request_size_bytes_total by server_port, handler, method, code, protocol
+counter http_response_size_bytes_total by server_port, handler, method, code, protocol
+
+histogram http_request_duration_seconds by server_port, handler, method, code, protocol buckets 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15
+
+/^/ +
+/(?P<server_port>\S+) / + # %v:%p - The canonical ServerName of the server serving the request. : The canonical port of the server serving the request.
+/(?P<handler>\S+) / + # %R - The handler generating the response (if any).
+/(?P<method>[A-Z]+) / + # %m - The request method.
+/(?P<code>\d{3}) / + # %>s - Status code.
+/(?P<protocol>\S+) / + # %H - The request protocol.
+/(?P<connection_status>conn=.) / + # %X - Connection status when response is completed
+/(?P<time_us>\d+) / + # %D - The time taken to serve the request, in microseconds.
+/(?P<sent_bytes>\d+) / + # %O - Bytes sent, including headers.
+/(?P<received_bytes>\d+) / + # %I - Bytes received, including request and headers.
+/(?P<keepalives>\d+)/ + # %k - Number of keepalive requests handled on this connection.
+/$/ {
+  ###
+  # HTTP Requests with histogram buckets.
+  #
+  http_request_duration_seconds[$server_port][$handler][$method][$code][$protocol] = $time_us / 1000000.0
+
+  ###
+  # Sent/Received bytes.
+  http_response_size_bytes_total[$server_port][$handler][$method][$code][$protocol] += $sent_bytes
+  http_request_size_bytes_total[$server_port][$handler][$method][$code][$protocol] += $received_bytes
+
+  ### Connection status when response is completed:
+  # X = Connection aborted before the response completed.
+  # + = Connection may be kept alive after the response is sent.
+  # - = Connection will be closed after the response is sent.
+  / conn=X / {
+    http_connections_aborted_total[$server_port][$handler][$method][$code][$protocol][$connection_status]++
+  }
+  # Will not include all closed connections. :-(
+  / conn=- / {
+    http_connections_closed_total[$server_port][$handler][$method][$code][$protocol][$connection_status]++
+  }
+}

--- a/playbooks/group_vars/all/apache2.yaml
+++ b/playbooks/group_vars/all/apache2.yaml
@@ -33,6 +33,9 @@ apache2__default_site_force_ssl: '{{ apache2__default_ssl_enable }}'
 # Rewrite request IPs when received from a reverse proxy using one of these
 # addresses.
 apache2__remoteip_from_proxies: []
+# Add a custom global logger for metric collection using mtail.
+apache2__add_metrics_log: '{{ mtail__enable }}'
+apache2__metrics_log: /var/log/apache2/metrics.log
 
 # Simple reverse proxy configuration.
 # -----------------------------------------------------------------------------
@@ -159,6 +162,17 @@ apache2__conf__remoteip:
         LogFormat {{ common_fmt | to_json }} common
       </IfModule>
 
+apache2__conf__metrics:
+  metrics:
+    state: |-
+      {{ 'enabled' if apache2__add_metrics_log else 'present' }}
+    src: |
+      LogFormat "%v:%p %R %m %>s %H conn=%X %D %O %I %k" metrics
+      GlobalLog {{ apache2__metrics_log }} metrics
+  # Remove old versions.
+  mtail:
+    state: absent
+
 apache2__mods__simple_proxy: |-
   {{
     _a2_mods_simple_proxy if apache2__simple_proxy is ansible.builtin.truthy
@@ -209,7 +223,6 @@ _a2_sites_simple_proxy: |-
 
     CustomLog ${APACHE_LOG_DIR}/{{ name }}/access.log combined
     ErrorLog ${APACHE_LOG_DIR}/{{ name }}/error.log
-    CustomLog ${APACHE_LOG_DIR}/metrics.log metrics
 
     ProxyPreserveHost On
     ProxyVia On

--- a/playbooks/group_vars/all/apt/external_repos.yaml
+++ b/playbooks/group_vars/all/apt/external_repos.yaml
@@ -13,48 +13,46 @@ apt__use_grafana_repo: |-
     ) is any
   }}
 apt__custom_sources__grafana: |-
-  {{ _apt_grafana_repo if apt__use_grafana_repo else {} }}
+  {{ dict(grafana=_apt_grafana_repo if apt__use_grafana_repo else None) }}
 apt__trusted_keys__grafana: |-
-  {{ _apt_grafana_key if apt__use_grafana_repo else {} }}
+  {{ dict(grafana=_apt_grafana_key if apt__use_grafana_repo else None) }}
 
 _apt_grafana_repo:
-  grafana:
-    mirror: https://packages.grafana.com/oss/deb
-    distro: stable
-    components: main
+  mirror: https://packages.grafana.com/oss/deb
+  distro: stable
+  components: main
 
 # To refresh, run:
 # $ wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | base64
-_apt_grafana_key:
-  grafana: |
-    mQGNBGTnhmkBDADUE+SzjRRyitIm1siGxiHlIlnn6KO4C4GfEuV+PNzqxvwYO+1rmcKlGDU0ugo8
-    ohXruAOC77Kwc4keVGNU89BeHvrYbIftz/yxEneuPsCbGnbDMIyCk44UOetRtV9/59Gj5YjNqnsZ
-    Cr+e5D/JfrHUJTTwKLv88A9eHKxskrlZr7Un7j3iEf3NChlOh2Zk9Wfk8IhAqMMTferU4iTIhQk+
-    5fanShtXIuzBaxU3lkzFSG7VuAH4CBLPWitKRMn5oqXUE0FZbRYL/6Qz0Gt6YCJsZbaQ3Am7FCwW
-    Cp9+ZHbR9yU+bkK0Dts4PNx4Wr9CktHIvbypT4Lk2oJEPWjcCJQHqpPQZXbnclXRlK5Ea0NVpaQd
-    GK+vJS4HGxFFjSkvTKAZYgwOk93qlpFeDML3TuSgWxuw4NIDitvewudnaWzfl9tDIoVSBb16nwJ8
-    bMDzovC/RBE14rRKYtMLmBsRzGYHWd0NnX+FitAS9uURHuFxghv9GFPheTaXvc4glM94HBUAEQEA
-    AbQmR3JhZmFuYSBMYWJzIDxlbmdpbmVlcmluZ0BncmFmYW5hLmNvbT6JAdQEEwEKAD4CGwMFCwkI
-    BwIGFQoJCAsCBBYCAwECHgECF4AWIQS1Oud7rbYwpoMEYAWWP6J3EEWFRQUCaKhvPQUJB4NP1AAK
-    CRCWP6J3EEWFRUjOC/9YdWOWJLJVKzLx8uv5YVzebyw15HevhKahbznJX5fHnE8irjkiPFltVEZ4
-    T37s5afRGBEJnR1UFd80s7jzwbuoZh/zEB3jN8q50g64AznuzDa0PWKzaY7Tgkssx3+hs6TSvIwV
-    4z8T7f56lDudeHxHXx+htRnZ3ebKNPCJS7+G12GF6W3C3znpdjgvhVUB0uxd+42V0fRqk2GLNZeK
-    S9988fi5dYRAy9Ozwced7ByCFjde9FBgUtrH3mG1/ibzLEh04k02nYjc8mrH32t4UCWpxQEJ1vZA
-    2vT2HN3/cH/4uyFdyU6OHkMyMbz6lmeXe71dF5hOB4+/RP6Ndyj7ViRNDbm70NRBaFne/+YOJvmM
-    fJTCh7YbF5qEn1ihGkJJ0ohEu2IB+EGEhyiDm8SIsj1uMw7n17iIPNtbsU5GgnmLtfguP/WbwKV2
-    UeuxTpiOeYb6blDwRlh48uHMlA5HBW+487Jktw3iPj1IKhdtAC9CU3xAvzDcseMbgmM6Xj2bSQG5
-    AY0EZOeGaQEMALNIFUricEIwtZiX7vSDjwxobbqPKqzdek8x3ud0CyYlrbGHy0k+FDEXstjJQQ1s
-    9rjJSu3sv5wyg9GDAUH3nzO976n/ZZvKPti3p2XU2UFx5gYkaaFVD56yYxqGY0YU5ft6BG+RUz3i
-    EPg3UBUzt0sCIYnG9+CsDqGOnRYIIa46fu2/H9Vu8JvvSq9xbsK9CfoQDkIcoQOixPuI4P7eHtsw
-    CeYR/1LUTWEnYQWsBCf57cEpzR6t7mlQnzQo9z4i/kp4S0ybDB77wnn+isMADOS+/VpXO+M7Zj5t
-    pfJ6PkKch3SGXdUy3zht8luFOYpJr2lVzp7n3NwB4zW08RptTzTgFAaW/NH2JjYI+rDvQm4jNs08
-    Dtspnm4OQvBA9Df/6qwMEOZ9i10ixqk+55UpQFJ3nf4uKlSUM7bKXXVcD/odq804Y/K4y3csE059
-    YVIyaPexEvYSYlHE2odJWRg2Q1VehmrOSC8Qps3xpU7dTHXD74ZpaYbrhaViRS5v/lCsiwARAQAB
-    iQG8BBgBCgAmAhsMFiEEtTrne622MKaDBGAFlj+idxBFhUUFAmiobzkFCQeDT9AACgkQlj+idxBF
-    hUVsmQwA0PA/zd7NqtnZ/Z8857gp2Wq2/e4EX8nRjsW2ZlrZfbU5oMQv9OZZ4z1UjIKEUV+TnCwX
-    EKXTMJomdekQSSayVVx/u5w+0YM8gRuQGrG8hW0GRR8sHIeuwBFlyQrlwxUwXvDOPDYyieETjaQq
-    MucupIKoIPm3CjFySvfizvSWUVSWBnGmQfpv6OiGYawvwfewcQHUdLMgWN3lYlzGQJL4+OMm7XcB
-    8VNTa586Q00fmjDfktHYvGpmhqr3gsd4gS3AjTk0zI65qXBRJkdqVnwUrMUD8TcxXYNXf90mhR0N
-    WkLmp6kBYiW8+QY6ndMmRVpodg1A87qgMYaZUAAlxCS4XKTUr+/YMDYOWgLN6i4UeYG/3/hsnAEH
-    m5ITojfh6cLfdlhjohFTnD0IYw3AsNJXRzKB1g5FTBKLLLIdXgS/3rWV1qjAd3drQVIMCku6HKl/
-    vT4ftrBHeSyV7eLwOYbe3/bw8VMx+lmMheD8/qJMia1om0iBBRSXRjY//f+Lllqm
+_apt_grafana_key: |
+  mQGNBGTnhmkBDADUE+SzjRRyitIm1siGxiHlIlnn6KO4C4GfEuV+PNzqxvwYO+1rmcKlGDU0ugo8
+  ohXruAOC77Kwc4keVGNU89BeHvrYbIftz/yxEneuPsCbGnbDMIyCk44UOetRtV9/59Gj5YjNqnsZ
+  Cr+e5D/JfrHUJTTwKLv88A9eHKxskrlZr7Un7j3iEf3NChlOh2Zk9Wfk8IhAqMMTferU4iTIhQk+
+  5fanShtXIuzBaxU3lkzFSG7VuAH4CBLPWitKRMn5oqXUE0FZbRYL/6Qz0Gt6YCJsZbaQ3Am7FCwW
+  Cp9+ZHbR9yU+bkK0Dts4PNx4Wr9CktHIvbypT4Lk2oJEPWjcCJQHqpPQZXbnclXRlK5Ea0NVpaQd
+  GK+vJS4HGxFFjSkvTKAZYgwOk93qlpFeDML3TuSgWxuw4NIDitvewudnaWzfl9tDIoVSBb16nwJ8
+  bMDzovC/RBE14rRKYtMLmBsRzGYHWd0NnX+FitAS9uURHuFxghv9GFPheTaXvc4glM94HBUAEQEA
+  AbQmR3JhZmFuYSBMYWJzIDxlbmdpbmVlcmluZ0BncmFmYW5hLmNvbT6JAdQEEwEKAD4CGwMFCwkI
+  BwIGFQoJCAsCBBYCAwECHgECF4AWIQS1Oud7rbYwpoMEYAWWP6J3EEWFRQUCaKhvPQUJB4NP1AAK
+  CRCWP6J3EEWFRUjOC/9YdWOWJLJVKzLx8uv5YVzebyw15HevhKahbznJX5fHnE8irjkiPFltVEZ4
+  T37s5afRGBEJnR1UFd80s7jzwbuoZh/zEB3jN8q50g64AznuzDa0PWKzaY7Tgkssx3+hs6TSvIwV
+  4z8T7f56lDudeHxHXx+htRnZ3ebKNPCJS7+G12GF6W3C3znpdjgvhVUB0uxd+42V0fRqk2GLNZeK
+  S9988fi5dYRAy9Ozwced7ByCFjde9FBgUtrH3mG1/ibzLEh04k02nYjc8mrH32t4UCWpxQEJ1vZA
+  2vT2HN3/cH/4uyFdyU6OHkMyMbz6lmeXe71dF5hOB4+/RP6Ndyj7ViRNDbm70NRBaFne/+YOJvmM
+  fJTCh7YbF5qEn1ihGkJJ0ohEu2IB+EGEhyiDm8SIsj1uMw7n17iIPNtbsU5GgnmLtfguP/WbwKV2
+  UeuxTpiOeYb6blDwRlh48uHMlA5HBW+487Jktw3iPj1IKhdtAC9CU3xAvzDcseMbgmM6Xj2bSQG5
+  AY0EZOeGaQEMALNIFUricEIwtZiX7vSDjwxobbqPKqzdek8x3ud0CyYlrbGHy0k+FDEXstjJQQ1s
+  9rjJSu3sv5wyg9GDAUH3nzO976n/ZZvKPti3p2XU2UFx5gYkaaFVD56yYxqGY0YU5ft6BG+RUz3i
+  EPg3UBUzt0sCIYnG9+CsDqGOnRYIIa46fu2/H9Vu8JvvSq9xbsK9CfoQDkIcoQOixPuI4P7eHtsw
+  CeYR/1LUTWEnYQWsBCf57cEpzR6t7mlQnzQo9z4i/kp4S0ybDB77wnn+isMADOS+/VpXO+M7Zj5t
+  pfJ6PkKch3SGXdUy3zht8luFOYpJr2lVzp7n3NwB4zW08RptTzTgFAaW/NH2JjYI+rDvQm4jNs08
+  Dtspnm4OQvBA9Df/6qwMEOZ9i10ixqk+55UpQFJ3nf4uKlSUM7bKXXVcD/odq804Y/K4y3csE059
+  YVIyaPexEvYSYlHE2odJWRg2Q1VehmrOSC8Qps3xpU7dTHXD74ZpaYbrhaViRS5v/lCsiwARAQAB
+  iQG8BBgBCgAmAhsMFiEEtTrne622MKaDBGAFlj+idxBFhUUFAmiobzkFCQeDT9AACgkQlj+idxBF
+  hUVsmQwA0PA/zd7NqtnZ/Z8857gp2Wq2/e4EX8nRjsW2ZlrZfbU5oMQv9OZZ4z1UjIKEUV+TnCwX
+  EKXTMJomdekQSSayVVx/u5w+0YM8gRuQGrG8hW0GRR8sHIeuwBFlyQrlwxUwXvDOPDYyieETjaQq
+  MucupIKoIPm3CjFySvfizvSWUVSWBnGmQfpv6OiGYawvwfewcQHUdLMgWN3lYlzGQJL4+OMm7XcB
+  8VNTa586Q00fmjDfktHYvGpmhqr3gsd4gS3AjTk0zI65qXBRJkdqVnwUrMUD8TcxXYNXf90mhR0N
+  WkLmp6kBYiW8+QY6ndMmRVpodg1A87qgMYaZUAAlxCS4XKTUr+/YMDYOWgLN6i4UeYG/3/hsnAEH
+  m5ITojfh6cLfdlhjohFTnD0IYw3AsNJXRzKB1g5FTBKLLLIdXgS/3rWV1qjAd3drQVIMCku6HKl/
+  vT4ftrBHeSyV7eLwOYbe3/bw8VMx+lmMheD8/qJMia1om0iBBRSXRjY//f+Lllqm

--- a/playbooks/group_vars/all/base_setup.yaml
+++ b/playbooks/group_vars/all/base_setup.yaml
@@ -15,6 +15,7 @@ base_setup__pkg_install__base:
   - cron
   - cron-apt
   - dbus
+  - linux-sysctl-defaults  # Need for non-root ping.
   - logrotate
   - mailutils
   - rsyslog

--- a/playbooks/group_vars/all/base_setup.yaml
+++ b/playbooks/group_vars/all/base_setup.yaml
@@ -14,6 +14,7 @@ base_setup__pkg_install__base:
   - acl  # Needed for becoming a non-root user.
   - cron
   - cron-apt
+  - dbus
   - logrotate
   - mailutils
   - rsyslog

--- a/playbooks/group_vars/all/fail2ban.yaml
+++ b/playbooks/group_vars/all/fail2ban.yaml
@@ -18,6 +18,7 @@ fail2ban__use_jail_apache2: '{{ apache2__enable | bool }}'
 # -----------------------------------------------------------------------------
 fail2ban__jail_config__00_default:
   DEFAULT:
+    banaction: iptables-multiport
     bantime: 10m
     bantime.increment: true
     maxretry: 5

--- a/playbooks/group_vars/all/mtail.yaml
+++ b/playbooks/group_vars/all/mtail.yaml
@@ -6,3 +6,27 @@
 
 mtail__enable: false
 mtail__install_ferm_svc: '{{ ferm__enable | bool }}'
+mtail__ferm_allow_from: '{{ trusted_networks }}'
+
+# Defaults for Apache2 logs.
+mtail__logs__apache2: |-
+  {{ [apache2__metrics_log] if apache2__add_metrics_log else [] }}
+mtail__programs__apache2: |-
+  {{ ['files/mtail/apache_metrics.mtail'] if apache2__add_metrics_log else [] }}
+
+# Agregation of custom configuration using var prefixes
+# -----------------------------------------------------------------------------
+
+mtail__logs: |-
+  {{
+    query('vars',
+      *(query('varnames', '^mtail__logs__.*') | sort)
+    ) | sum(start=[])
+  }}
+
+mtail__programs: |-
+  {{
+    query('vars',
+      *(query('varnames', '^mtail__programs__.*') | sort)
+    ) | sum(start=[])
+  }}

--- a/playbooks/group_vars/libvirt_hosts.yaml
+++ b/playbooks/group_vars/libvirt_hosts.yaml
@@ -24,6 +24,7 @@ users__create_groups__libvirt:
 
 apt__packages_to_install__libvirt:
   - prometheus-libvirt-exporter
+  - qemu-system-modules-spice
   # required by community.libvirt.virt
   - python3-libvirt
 apt__services_to_enable__libvirt:

--- a/roles/restic_backup/tasks/main.yaml
+++ b/roles/restic_backup/tasks/main.yaml
@@ -38,4 +38,4 @@
     dest: /etc/cron.daily/restic_backup
     owner: root
     group: root
-    mode: '0775'
+    mode: '0700'  # The repository URL may contain a password.

--- a/roles/restic_backup/tasks/main.yaml
+++ b/roles/restic_backup/tasks/main.yaml
@@ -25,7 +25,7 @@
     group: root
     mode: '0600'
   no_log: true
-  when: restic_backup__password
+  when: restic_backup__password is ansible.builtin.truthy
 
 - name: Set up cron job
   ansible.builtin.copy:


### PR DESCRIPTION
* create_vm: disable cloud-init & systemd-networkd before first boot
* base_setup: install dbus by default
  Without dbus, many systemd operations cannot be run as a normal user
* base_setup: install linux-sysctl-defaults by default
  Need for non-root ping since trixie.
* fail2ban: set `banaction` explicitly
  Without this setting, the glue between ferm and fail2ban is broken in trixie.
* restic_backup: tighten file permissions
* apache2: add setting to enable metrics collection log
* mtail: add defaults for Apache2 log collection
* libvirt_hosts: add needed package for spice graphics